### PR TITLE
Add competitor analysis document

### DIFF
--- a/COMPETITOR_ANALYSIS.md
+++ b/COMPETITOR_ANALYSIS.md
@@ -1,0 +1,131 @@
+# Competitor Analysis — Glitch Text Generator
+
+_Last updated: 2026-04-15_
+
+Comparison of this site against the leading glitch/zalgo text generator competitors, with identified feature gaps and monetisation findings.
+
+## Competitors reviewed
+
+- [LingoJam](https://lingojam.com/GlitchTextGenerator)
+- [Zalgo.org](https://zalgo.org/)
+- [FSymbols](https://fsymbols.com/generators/glitch/)
+- [FancyTextGuru](https://fancytextguru.com/glitch-text-generator)
+- [Textavia](https://textavia.com/tools/glitch-text-converter)
+- [CodeShack](https://codeshack.io/zalgo-text-generator/)
+- [WUTools](https://wutools.com/text/zalgo-text-generator)
+- [MonoCalc](https://monocalc.com/tool/text/zalgo_text_generator)
+- [Pixelied](https://pixelied.com/font-generator/glitch-text)
+- [Picsart Quicktools](https://tools.picsart.com/text/font-generator/glitch/)
+- [Glyphy](https://glyphy.io/font-generator/glitch-text)
+- [Creative Fabrica](https://www.creativefabrica.com/tools/glitch-text-generator/)
+- [glitch-textgenerator.com](https://glitch-textgenerator.com/)
+- [Skywork AI](https://skywork.ai/)
+
+## What this site already has
+
+- 25+ generator pages (vaporwave, small caps, gothic, cursive, graffiti, etc.)
+- 5 glitch effects: Zalgo, ASCII, Binary, CRT Scanline, Datamosh
+- Intensity (0–10) + animation speed sliders
+- 4 font family styles + color schemes
+- Image download (PNG / GIF), copy-to-clipboard, social share
+- `/text-to-image` export
+- Strong SEO content moat (guides, examples, platform-specific pages)
+- Minecraft / Roblox / Discord specific generators
+
+## Feature gaps vs. competitors
+
+### Critical (P0 — table-stakes parity)
+
+| # | Gap | Competitors that have it | Why it matters |
+|---|---|---|---|
+| 1 | **Up / Middle / Down directional toggles** on the Zalgo engine | zalgo.org, CodeShack, WUTools, MonoCalc | Single most common feature we lack. Users expect smoke/dripping/strike-through variants. |
+| 2 | **Character counter + platform-limit hints** (Twitter, Discord nickname, IG bio) | Most modern tools | Glitch text inflates byte counts dramatically; users paste and get truncated. |
+| 3 | **Canonical URLs + Schema.org rich snippets** | Most competitors | Already in `TODO.md`. With 50+ overlapping routes we risk duplicate-content penalties. |
+
+### High (P1 — differentiation / retention)
+
+| # | Gap | Competitors that have it |
+|---|---|---|
+| 4 | **Favorites** (localStorage) | Textavia |
+| 5 | **Generation history** (recent outputs) | Most modern tools |
+| 6 | **Unified "all fonts" gallery page** with per-row copy buttons | LingoJam, FSymbols, FancyTextGuru |
+| 7 | **Randomize / regenerate / shuffle** button | Pixelied, Picsart, Textavia |
+| 8 | **Named presets** beyond "Extreme" (Subtle / Medium / Heavy / Zalgo-Lite / Eldritch) | Most |
+| 9 | **Dark mode** | ~all (already in `TODO.md`) |
+
+### Medium (P2 — differentiation)
+
+| # | Gap | Notes |
+|---|---|---|
+| 10 | **Platform-specific preview mockups** (Discord / IG / Twitter bubble) | Few do this well — opportunity |
+| 11 | **Unglitch / decoder / cleaner tool** | No competitor does this — differentiator |
+| 12 | **Public API docs + embeddable widget** | Only glitch-textgenerator.com advertises one |
+| 13 | **Accessibility pass** (ARIA, screen-reader alt, warnings) | Underserved across the market |
+| 14 | **Emoji / symbol inserter** | Textavia, Picsart |
+
+### Low (P3 — polish)
+
+- PWA / offline / installable manifest
+- Keyboard shortcut to copy + toast confirmation
+- Multi-line / paragraph handling messaging
+- TikTok / Threads / BlueSky platform copy (currently Discord / IG / Twitter / Roblox only)
+
+## Recommended priority order
+
+| Priority | Feature | Effort | Impact |
+|---|---|---|---|
+| P0 | Up/Middle/Down toggles | Low | High |
+| P0 | Character counter + platform limits | Low | High |
+| P0 | Canonical URLs + Schema.org | Low | High |
+| P1 | Favorites (localStorage) + history | Med | Med |
+| P1 | Unified "all fonts" gallery | Med | High |
+| P1 | Randomize button | Low | Med |
+| P1 | Dark mode | Low | Med |
+| P2 | Platform mockup previews | Med | Med |
+| P2 | Unglitch / decoder | Low | Med |
+| P2 | Public API + embed | High | Med |
+| P3 | PWA, a11y, TikTok/Threads copy | Med | Low/Med |
+
+## Monetisation landscape
+
+**Summary:** essentially all competitors monetise, but nearly exclusively via display ads. The standalone glitch/zalgo tools have no paid tiers. Only general design suites that bundle glitch-text generation as a lead magnet operate freemium plans.
+
+### Ad-supported only (no paywall)
+
+| Site | Model | Notes |
+|---|---|---|
+| LingoJam | Display ads | ~656K daily visitors, ~$1,254/day ad revenue, ~$338K/year |
+| FSymbols | Display ads | Standard utility-site ad layout |
+| FancyTextGuru | Display ads | Same pattern |
+| Zalgo.org, CodeShack, WUTools, MonoCalc, Textavia, psd-dude, convertcase | Display ads | All free, no accounts |
+| glitch-textgenerator.com | Ads + advertised API | No confirmed paid API tier |
+
+### Freemium (glitch text as a funnel into a larger suite)
+
+| Site | Plan | What is gated |
+|---|---|---|
+| Picsart / Quicktools | Picsart Plus ~$13/mo | HD PNG export, watermark removal, advanced editor features. Glitch generator itself is free. |
+| Pixelied | Pixelied Pro | Graphic suite features; glitch page free. |
+| Kapwing | Credit-based Pro | AI image-glitch generator; higher-res outputs, removed limits. |
+| Skywork AI | Freemium + Pro | Heavy usage + higher-res image assets behind Pro. |
+| Creative Fabrica | Subscription | Glitch tool funnels into their font/asset marketplace. |
+
+### Implications for this site
+
+1. **Standalone glitch market is an ads game.** LingoJam's ~$338K/year on ~200M annual visits sets a realistic ceiling for pure-utility monetisation.
+2. **Two viable revenue paths:**
+   - **Display ads** (AdSense / Mediavine / Ezoic) — requires scale; existing SEO moat supports this.
+   - **Freemium on exports, not inputs** — keep copy-paste text 100% free, charge for adjacent outputs: HD / transparent PNG, longer GIFs, MP4 video glitch export, branded templates, batch processing, API access.
+3. **White space:** no dedicated glitch-text competitor monetises image/video exports today. We already have `/download` (PNG / GIF) and `/text-to-image` — this is the clearest product surface to experiment with a paid tier.
+4. **API as a paid tier:** glitch-textgenerator.com only *advertises* an API; no one ships a real documented paid developer tier. Small but defensible niche.
+
+## Sources
+
+- [LingoJam revenue estimate (Owler)](https://www.owler.com/company/lingojam)
+- [LingoJam traffic (Similarweb)](https://www.similarweb.com/website/lingojam.com/)
+- [Picsart Glitch (free)](https://tools.picsart.com/text/font-generator/glitch/)
+- [Pixelied Glitch](https://pixelied.com/font-generator/glitch-text)
+- [Creative Fabrica Glitch Tool](https://www.creativefabrica.com/tools/glitch-text-generator/)
+- [Glyphy Glitch](https://glyphy.io/font-generator/glitch-text)
+- [Filmora — 9 best glitch text generators](https://filmora.wondershare.com/video-editing-tools/glitch-text-generator.html)
+- [CapCut — 6 best glitch text generators](https://www.capcut.com/resource/glitch-text-generator)


### PR DESCRIPTION
## Summary

Adds `COMPETITOR_ANALYSIS.md` — a written comparison of this site against the leading glitch/zalgo text generator competitors (LingoJam, Zalgo.org, FSymbols, FancyTextGuru, Textavia, CodeShack, WUTools, MonoCalc, Pixelied, Picsart, Glyphy, Creative Fabrica, glitch-textgenerator.com, Skywork AI).

The document covers:

- **Current feature inventory** — what this site already ships
- **Prioritised feature gaps** (P0–P3) vs. competitors, e.g.:
  - P0: Up/Middle/Down directional Zalgo toggles, character counter + platform limits, canonical URLs + Schema.org
  - P1: Favorites, history, unified "all fonts" gallery, randomize, dark mode
  - P2: Platform preview mockups, unglitch/decoder tool, public API + embed, a11y pass
  - P3: PWA, TikTok/Threads/BlueSky platform copy
- **Monetisation landscape** — standalone glitch tools are pure display-ad plays (LingoJam: ~$338K/year on ~656K daily visitors); only general design suites (Picsart, Pixelied, Kapwing, Skywork, Creative Fabrica) run freemium plans. Identifies white space in paid image/video export and a documented developer API.

No code changes in this PR — documentation only. Implementation of the P0 items is deliberately deferred.

## Test plan

- [ ] Review `COMPETITOR_ANALYSIS.md` renders correctly on GitHub
- [ ] Sanity-check the prioritised gap list matches the team's product direction before opening implementation PRs
